### PR TITLE
struct page_list bug

### DIFF
--- a/dm-dedup-rw.c
+++ b/dm-dedup-rw.c
@@ -166,7 +166,7 @@ static struct bio *prepare_bio_with_pbn(struct dedup_config *dc,
 	struct page_list *pl;
 	struct bio *clone = NULL;
 
-	pl = kmalloc(sizeof(pl), GFP_NOIO);
+	pl = kmalloc(sizeof(struct page_list), GFP_NOIO);
 	if (!pl)
 		goto out;
 


### PR DESCRIPTION
This BUG existed because of using a pointer instead of a struct as an argument to the sizeof().
Replaced it with the structure name.
