### PR TITLE
Fixing incorrect page allocation in read-modify-write code path

### DIFF
--- a/dm-dedup-rw.c
+++ b/dm-dedup-rw.c
@@ -166,7 +166,7 @@ static struct bio *prepare_bio_with_pbn(struct dedup_config *dc,
 	struct page_list *pl;
 	struct bio *clone = NULL;
 
-	pl = kmalloc(sizeof(pl), GFP_NOIO);
+	pl = kmalloc(sizeof(*pl), GFP_NOIO);
 	if (!pl)
 		goto out;
 


### PR DESCRIPTION
Replacing sizeof(p) with sizeof(*p) in kmalloc()
