### PR TITLE
Fix to properly access bio_vecs using bi_iter via macros in read-modify-write code path

### DIFF
--- a/dm-dedup-rw.c
+++ b/dm-dedup-rw.c
@@ -55,6 +55,8 @@ static int merge_data(struct dedup_config *dc, struct page *page,
 	sector_t bi_sector = bio->bi_iter.bi_sector;
 	void *src_page_vaddr, *dest_page_vaddr;
 	int position, err = 0;
+	struct bvec_iter iter;
+	struct bio_vec bvec;
 
 	/* Relative offset in terms of sector size */
 	position = sector_div(bi_sector, dc->sectors_per_block);
@@ -64,15 +66,19 @@ static int merge_data(struct dedup_config *dc, struct page *page,
 		goto out;
 	}
 
-	src_page_vaddr = page_address(bio->bi_io_vec->bv_page);
-	dest_page_vaddr = page_address(page);
-
-	src_page_vaddr = src_page_vaddr + bio->bi_io_vec->bv_offset;
 	/* Locating the right sector to merge */
-	dest_page_vaddr = dest_page_vaddr + (to_bytes(position));
+	dest_page_vaddr = page_address(page) + to_bytes(position);
 
-	/* Merging Data */
-	memmove(dest_page_vaddr, src_page_vaddr, bio->bi_io_vec->bv_len);
+	bio_for_each_segment(bvec, bio, iter) {
+		src_page_vaddr = bio_data(bio);
+
+		/* Merging Data */
+		memmove(dest_page_vaddr, src_page_vaddr, bio_cur_bytes(bio));
+
+		/* Updating destination address */
+		dest_page_vaddr += bio_cur_bytes(bio);
+    }
+
 out:
 	return err;
 }
@@ -82,7 +88,7 @@ static void copy_pages(struct page *src, struct bio *clone)
 	void *src_page_vaddr, *dest_page_vaddr;
 
 	src_page_vaddr = page_address(src);
-	dest_page_vaddr = page_address(clone->bi_io_vec->bv_page);
+	dest_page_vaddr = page_address(bio_page(clone));
 
 	memmove(dest_page_vaddr, src_page_vaddr, DMD_IO_SIZE);
 }
@@ -216,7 +222,7 @@ static struct bio *prepare_bio_without_pbn(struct dedup_config *dc,
 	if (!clone)
 		goto out;
 
-	my_zero_fill_bio(clone);
+	zero_fill_bio(clone);
 
 	r = merge_data(dc, clone->bi_io_vec->bv_page, bio);
 	if (r < 0)


### PR DESCRIPTION
Replaced direct accesses to bi_io_vec with appropriate macros
