### PR TITLE
Fix the dmsetup status output format to comply with documentation format

### DIFF
--- a/dm-dedup-target.c
+++ b/dm-dedup-target.c
@@ -11,6 +11,7 @@
  */
 
 #include <linux/vmalloc.h>
+#include <linux/kdev_t.h>
 
 #include "dm-dedup-target.h"
 #include "dm-dedup-rw.h"
@@ -847,6 +848,13 @@ static void dm_dedup_status(struct dm_target *ti, status_type_t status_type,
 		DMEMIT("%llu %llu %llu %llu ",
 			data_total_block_count, data_free_block_count,
 			data_used_block_count, data_actual_block_count);
+
+		DMEMIT("%d %d:%d %d:%d ",
+			dc->block_size,
+			MAJOR(dc->data_dev->bdev->bd_dev),
+			MINOR(dc->data_dev->bdev->bd_dev),
+			MAJOR(dc->metadata_dev->bdev->bd_dev),
+			MINOR(dc->metadata_dev->bdev->bd_dev));
 
 		DMEMIT("%llu %llu %llu %llu %llu %llu",
 			dc->writes, dc->uniqwrites, dc->dupwrites,


### PR DESCRIPTION
Added DMEMIT for the following three parameters wrt the documentation format:

block size , data_Device -minor:major , metadata_device - minor:major