### PR TITLE
Fix for free_pages crash in read-modify-write code path

### DIFF
--- a/dm-dedup-rw.c
+++ b/dm-dedup-rw.c
@@ -96,17 +96,17 @@ static void my_endio(struct bio *clone, int error)
 {
 	unsigned rw = bio_data_dir(clone);
 	struct bio *orig;
-	struct bio_vec bv;
+	struct bio_vec *bv;
 
 	if (!error && !bio_flagged(clone, BIO_UPTODATE))
 		error = -EIO;
 
 	/* free the processed pages */
 	if (rw == WRITE || rw == READ) {
-		bv = bio_iovec(clone);
-		if (bv.bv_page) {
-			free_pages((unsigned long)page_address(bv.bv_page), 0);
-			bv.bv_page = NULL;
+		bv = clone->bi_io_vec;
+		if (bv->bv_page) {
+			free_pages((unsigned long)page_address(bv->bv_page), 0);
+			bv->bv_page = NULL;
 		}
 	}
 

--- a/dm-dedup-target.c
+++ b/dm-dedup-target.c
@@ -334,8 +334,10 @@ static int handle_write(struct dedup_config *dc, struct bio *bio)
 	if (bio->bi_iter.bi_size < dc->block_size) {
 		dc->reads_on_writes++;
 		new_bio = prepare_bio_on_write(dc, bio);
-		if (!new_bio || IS_ERR(new_bio))
+		if (!new_bio)
 			return -ENOMEM;
+		else if(IS_ERR(new_bio))
+			return PTR_ERR(new_bio);
 		bio = new_bio;
 	}
 


### PR DESCRIPTION
Macro to create local copy returning wrong page address sometimes.
So access bio_vec of clone by reference instead of creating a local copy.