### PR TITLE
Fix for free_pages crash in read-modify-write code path

### DIFF
--- a/dm-dedup-rw.c
+++ b/dm-dedup-rw.c
@@ -96,17 +96,17 @@ static void my_endio(struct bio *clone, int error)
 {
 	unsigned rw = bio_data_dir(clone);
 	struct bio *orig;
-	struct bio_vec bv;
+	struct bio_vec *bv;
 
 	if (!error && !bio_flagged(clone, BIO_UPTODATE))
 		error = -EIO;
 
 	/* free the processed pages */
 	if (rw == WRITE || rw == READ) {
-		bv = bio_iovec(clone);
-		if (bv.bv_page) {
-			free_pages((unsigned long)page_address(bv.bv_page), 0);
-			bv.bv_page = NULL;
+		bv = clone->bi_io_vec;
+		if (bv->bv_page) {
+			free_pages((unsigned long)page_address(bv->bv_page), 0);
+			bv->bv_page = NULL;
 		}
 	}
 


### PR DESCRIPTION
Macro to create local copy returning wrong page address sometimes.
So access bio_vec of clone by reference instead of creating a local copy.