### PR TITLE
shash and bio fixes for latest & old kernels

### DIFF
--- a/dm-dedup-hash.h
+++ b/dm-dedup-hash.h
@@ -13,10 +13,43 @@
 #ifndef DM_DEDUP_HASH_H
 #define DM_DEDUP_HASH_H
 
+#include <linux/version.h>
+
 #define DEDUP_HASH_DESC_COUNT 128
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) //4.6.0-rc1
+#define SHASH 1
+#define crypto_alloc_hash crypto_alloc_shash
+#define crypto_hash_final crypto_shash_final
+#define crypto_hash_init crypto_shash_init
+#define crypto_hash_update crypto_shash_update
+#define crypto_hash_digestsize crypto_shash_digestsize
+#define crypto_free_hash crypto_free_shash
+#define hash_desc shash_desc
+#endif
+
+static inline int crypto_has_hash(const char *alg_name, u32 type, u32 mask)
+{
+        type &= ~CRYPTO_ALG_TYPE_MASK;
+        mask &= ~CRYPTO_ALG_TYPE_MASK;
+        type |= CRYPTO_ALG_TYPE_SHASH;
+        mask |= CRYPTO_ALG_TYPE_HASH_MASK;
+
+        return crypto_has_alg(alg_name, type, mask);
+}
+
 struct hash_desc_table {
+#if SHASH
+	union{
+		/*Made as pointer from array to extra data allocation for context/state*/
+		struct shash_desc *shd;//[DEDUP_HASH_DESC_COUNT];
+		/*Added void pointer for better access, to increment byte wise*/
+		void *desc;
+	};
+	uint32_t desc_state_size;
+#else
 	struct hash_desc desc[DEDUP_HASH_DESC_COUNT];
+#endif
 	bool free_bitmap[DEDUP_HASH_DESC_COUNT];
 	atomic_long_t slot_counter;
 } /*desc_table*/;

--- a/dm-dedup-target.c
+++ b/dm-dedup-target.c
@@ -26,6 +26,13 @@
 #define MIN_DATA_DEV_BLOCK_SIZE (4 * 1024)
 #define MAX_DATA_DEV_BLOCK_SIZE (1024 * 1024)
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) // 4.8-rc1
+#define bi_rw bi_opf
+#ifndef REQ_FLUSH
+#define REQ_FLUSH REQ_PREFLUSH
+#endif
+#endif
+
 struct on_disk_stats {
 	uint64_t physical_block_counter;
 	uint64_t logical_block_counter;


### PR DESCRIPTION
Fixed bio & shash interface issues for latest kernels and supports backward compatibility.
For bio bi_opf is introduced in place of bi_rw. Couple of bio_API signature changes. 
bio_API signatures i haven't corrected in this pull request., Because i want to add backward compatibility older kernels.