### PR TITLE
Save statistics in CBT backend

### DIFF
--- a/dm-dedup-backend.h
+++ b/dm-dedup-backend.h
@@ -19,6 +19,11 @@ struct kvstore;			/* key-value store identifier */
 #define BF_NEGATIVE -1
 #define BF_POSITIVE 0
 
+struct on_disk_stats {
+        uint64_t physical_block_counter;
+        uint64_t logical_block_counter;
+};
+
 struct metadata_ops {
 	/*
 	 * Returns ERR_PTR(*) on error.

--- a/dm-dedup-target.c
+++ b/dm-dedup-target.c
@@ -26,11 +26,6 @@
 #define MIN_DATA_DEV_BLOCK_SIZE (4 * 1024)
 #define MAX_DATA_DEV_BLOCK_SIZE (1024 * 1024)
 
-struct on_disk_stats {
-	uint64_t physical_block_counter;
-	uint64_t logical_block_counter;
-};
-
 /*
  * All incoming requests are packed in the dedup_work structure
  * for further processing by the workqueue thread.
@@ -617,7 +612,8 @@ static int dm_dedup_ctr(struct dm_target *ti, unsigned int argc, char **argv)
 	int r;
 	int crypto_key_size;
 
-	struct on_disk_stats *data = NULL;
+	struct on_disk_stats d;
+	struct on_disk_stats *data = &d;
 	uint64_t logical_block_counter = 0;
 	uint64_t physical_block_counter = 0;
 


### PR DESCRIPTION
Implemented set_private_data and get_private_data functions to save physical and logical block counters